### PR TITLE
fix: send 0 to nvim_buf_get_lines if self.bufnr is nil

### DIFF
--- a/lua/cmp-pandoc-references/init.lua
+++ b/lua/cmp-pandoc-references/init.lua
@@ -15,7 +15,7 @@ source.get_keyword_pattern = function()
 end
 
 source.complete = function(self, request, callback)
-  local lines = vim.api.nvim_buf_get_lines(self.bufnr, 0, -1, false)
+  local lines = vim.api.nvim_buf_get_lines(self.bufnr or 0, 0, -1, false)
   local entries = refs.get_entries(lines)
 
   if entries then


### PR DESCRIPTION
Following [https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147](https://github.com/neovim/neovim/issues/14090#issuecomment-1004318147), the function couldn't take nil as an implicit first argument. This PR correct an error which is raised when self.bufnr is nil by sending 0 (which was the previous behavior)
