### PR TITLE
add quarto filetype

### DIFF
--- a/lua/cmp-pandoc-references/init.lua
+++ b/lua/cmp-pandoc-references/init.lua
@@ -7,7 +7,7 @@ end
 
 -- Add another filetype if needed
 source.is_available = function()
-	return vim.o.filetype == 'pandoc' or vim.o.filetype == 'markdown' or vim.o.filetype == 'rmd'
+	return vim.o.filetype == 'pandoc' or vim.o.filetype == 'markdown' or vim.o.filetype == 'rmd' or vim.o.filetype == 'qmd'
 end
 
 source.get_keyword_pattern = function()


### PR DESCRIPTION
quarto is a scientific and computational notebook format built on top of pandoc (sort of the next evolution of rmarkdown): https://quarto.org/
As of now I am using regular markdown as the filetype for the quarto nvim extension, but would like to prepare for quarto specific features, so I am adding the filetype here in advance.