### PR TITLE
allow crossref types used by quarto

### DIFF
--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -52,7 +52,13 @@ end
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
 	local words = table.concat(lines, '\n')
-	for ref in words:gmatch('[({#)(#%| label: )](%a+[:%-][%w_-]+)') do
+	for ref in words:gmatch('{#(%a+[:%-][%w_-]+)') do
+		local entry = {}
+		entry.label = '@' .. ref
+		entry.kind = cmp.lsp.CompletionItemKind.Reference
+		table.insert(entries, entry)
+	end
+	for ref in words:gmatch('#| label: (%a+[:%-][%w_-]+)') do
 		local entry = {}
 		entry.label = '@' .. ref
 		entry.kind = cmp.lsp.CompletionItemKind.Reference

--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -52,7 +52,7 @@ end
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
 	local words = table.concat(lines)
-	for ref in words:gmatch('{#(%a+:[%w_-]+)') do
+	for ref in words:gmatch('{#(%a+[:-][%w_-]+)') do
 		local entry = {}
 		entry.label = '@' .. ref
 		entry.kind = cmp.lsp.CompletionItemKind.Reference

--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -51,8 +51,8 @@ end
 
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
-	local words = table.concat(lines)
-	for ref in words:gmatch('{#(%a+[:%-][%w_-]+)') do
+	local words = table.concat(lines, '\n')
+	for ref in words:gmatch('[({#)(#%| label: )](%a+[:%-][%w_-]+)') do
 		local entry = {}
 		entry.label = '@' .. ref
 		entry.kind = cmp.lsp.CompletionItemKind.Reference

--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -52,7 +52,7 @@ end
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
 	local words = table.concat(lines)
-	for ref in words:gmatch('{#(%a+[:-][%w_-]+)') do
+	for ref in words:gmatch('{#(%a+[:%-][%w_-]+)') do
 		local entry = {}
 		entry.label = '@' .. ref
 		entry.kind = cmp.lsp.CompletionItemKind.Reference


### PR DESCRIPTION
This makes it compatible with quarto cross references (https://quarto.org/docs/authoring/cross-references.html), which is built on top of pandoc but uses `-` to separate the type of the reference (like `fig` or `eq`) from the rest of the label.
The PR allows for both separators.

Further, it detects references created by code blocks via their label attribute (https://quarto.org/docs/reference/cells/cells-knitr.html#attributes)