### PR TITLE
Quarto bib location

### DIFF
--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -6,11 +6,24 @@ local M = {}
 -- (Crudely) Locates the bibliography
 local function locate_bib(lines)
 	for _, line in ipairs(lines) do
-		location = string.match(line, 'bibliography: (%g+)')
+		local location = string.match(line, 'bibliography: (%g+)')
 		if location then
 			return location
 		end
 	end
+  -- no bib locally defined
+  -- test for quarto project-wide definition
+  local fname = vim.api.nvim_buf_get_name(0)
+  local root = require 'lspconfig.util'.root_pattern('_quarto.yml')(fname)
+  if root then
+    local file = root .. '/_quarto.yml'
+    for line in io.lines(file) do
+      local location = string.match(line, 'bibliography: (%g+)')
+      if location then
+        return location
+      end
+    end
+  end
 end
 
 -- Remove newline & excessive whitespace

--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -5,25 +5,12 @@ local M = {}
 
 -- (Crudely) Locates the bibliography
 local function locate_bib(lines)
-  for _, line in ipairs(lines) do
-    local location = string.match(line, 'bibliography: (%g+)')
-    if location then
-      return location
-    end
-  end
-  -- no bib locally defined
-  -- test for quarto project-wide definition
-  local fname = vim.api.nvim_buf_get_name(0)
-  local root = require 'lspconfig.util'.root_pattern('_quarto.yml')(fname)
-  if root then
-    local file = root .. '/_quarto.yml'
-    for line in io.lines(file) do
-      local location = string.match(line, 'bibliography: (%g+)')
-      if location then
-        return location
-      end
-    end
-  end
+	for _, line in ipairs(lines) do
+		location = string.match(line, 'bibliography: (%g+)')
+		if location then
+			return location
+		end
+	end
 end
 
 -- Remove newline & excessive whitespace
@@ -39,51 +26,51 @@ end
 -- Parses the .bib file, formatting the completion item
 -- Adapted from http://rgieseke.github.io/ta-bibtex/
 local function parse_bib(filename)
-  local file = io.open(filename, 'rb')
-  local bibentries = file:read('*all')
-  file:close()
-  for bibentry in bibentries:gmatch('@.-\n}\n') do
-    local entry = {}
+	local file = io.open(filename, 'rb')
+	local bibentries = file:read('*all')
+	file:close()
+	for bibentry in bibentries:gmatch('@.-\n}\n') do
+		local entry = {}
 
-    local title = clean(bibentry:match('title%s*=%s*["{]*(.-)["}],?')) or ''
-    local author = clean(bibentry:match('author%s*=%s*["{]*(.-)["}],?')) or ''
-    local year = bibentry:match('year%s*=%s*["{]?(%d+)["}]?,?') or ''
+		local title = clean(bibentry:match('title%s*=%s*["{]*(.-)["}],?')) or ''
+		local author = clean(bibentry:match('author%s*=%s*["{]*(.-)["}],?')) or ''
+		local year = bibentry:match('year%s*=%s*["{]?(%d+)["}]?,?') or ''
 
-    local doc = { '**' .. title .. '**', '', '*' .. author .. '*', year }
+		local doc = {'**' .. title .. '**', '', '*' .. author .. '*', year}
 
-    entry.documentation = {
-      kind = cmp.lsp.MarkupKind.Markdown,
-      value = table.concat(doc, '\n')
-    }
-    entry.label = '@' .. bibentry:match('@%w+{(.-),')
-    entry.kind = cmp.lsp.CompletionItemKind.Reference
+		entry.documentation = {
+			kind = cmp.lsp.MarkupKind.Markdown,
+			value = table.concat(doc, '\n')
+		}
+		entry.label = '@' .. bibentry:match('@%w+{(.-),')
+		entry.kind = cmp.lsp.CompletionItemKind.Reference
 
-    table.insert(entries, entry)
-  end
+		table.insert(entries, entry)
+	end
 end
 
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
-  local words = table.concat(lines)
-  for ref in words:gmatch('{#(%a+:[%w_-]+)') do
-    local entry = {}
-    entry.label = '@' .. ref
-    entry.kind = cmp.lsp.CompletionItemKind.Reference
-    table.insert(entries, entry)
-  end
+	local words = table.concat(lines)
+	for ref in words:gmatch('{#(%a+:[%w_-]+)') do
+		local entry = {}
+		entry.label = '@' .. ref
+		entry.kind = cmp.lsp.CompletionItemKind.Reference
+		table.insert(entries, entry)
+	end
 end
 
 -- Returns the entries as a table, clearing entries beforehand
 function M.get_entries(lines)
-  local location = locate_bib(lines)
-  entries = {}
+	local location = locate_bib(lines)
+	entries = {}
 
-  if location and vim.fn.filereadable(location) == 1 then
-    parse_bib(location)
-  end
-  parse_ref(lines)
+	if location and vim.fn.filereadable(location) == 1 then
+		parse_bib(location)
+	end
+	parse_ref(lines)
 
-  return entries
+	return entries
 end
 
 return M

--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -5,12 +5,25 @@ local M = {}
 
 -- (Crudely) Locates the bibliography
 local function locate_bib(lines)
-	for _, line in ipairs(lines) do
-		location = string.match(line, 'bibliography: (%g+)')
-		if location then
-			return location
-		end
-	end
+  for _, line in ipairs(lines) do
+    local location = string.match(line, 'bibliography: (%g+)')
+    if location then
+      return location
+    end
+  end
+  -- no bib locally defined
+  -- test for quarto project-wide definition
+  local fname = vim.api.nvim_buf_get_name(0)
+  local root = require 'lspconfig.util'.root_pattern('_quarto.yml')(fname)
+  if root then
+    local file = root .. '/_quarto.yml'
+    for line in io.lines(file) do
+      local location = string.match(line, 'bibliography: (%g+)')
+      if location then
+        return location
+      end
+    end
+  end
 end
 
 -- Remove newline & excessive whitespace
@@ -26,51 +39,51 @@ end
 -- Parses the .bib file, formatting the completion item
 -- Adapted from http://rgieseke.github.io/ta-bibtex/
 local function parse_bib(filename)
-	local file = io.open(filename, 'rb')
-	local bibentries = file:read('*all')
-	file:close()
-	for bibentry in bibentries:gmatch('@.-\n}\n') do
-		local entry = {}
+  local file = io.open(filename, 'rb')
+  local bibentries = file:read('*all')
+  file:close()
+  for bibentry in bibentries:gmatch('@.-\n}\n') do
+    local entry = {}
 
-		local title = clean(bibentry:match('title%s*=%s*["{]*(.-)["}],?')) or ''
-		local author = clean(bibentry:match('author%s*=%s*["{]*(.-)["}],?')) or ''
-		local year = bibentry:match('year%s*=%s*["{]?(%d+)["}]?,?') or ''
+    local title = clean(bibentry:match('title%s*=%s*["{]*(.-)["}],?')) or ''
+    local author = clean(bibentry:match('author%s*=%s*["{]*(.-)["}],?')) or ''
+    local year = bibentry:match('year%s*=%s*["{]?(%d+)["}]?,?') or ''
 
-		local doc = {'**' .. title .. '**', '', '*' .. author .. '*', year}
+    local doc = { '**' .. title .. '**', '', '*' .. author .. '*', year }
 
-		entry.documentation = {
-			kind = cmp.lsp.MarkupKind.Markdown,
-			value = table.concat(doc, '\n')
-		}
-		entry.label = '@' .. bibentry:match('@%w+{(.-),')
-		entry.kind = cmp.lsp.CompletionItemKind.Reference
+    entry.documentation = {
+      kind = cmp.lsp.MarkupKind.Markdown,
+      value = table.concat(doc, '\n')
+    }
+    entry.label = '@' .. bibentry:match('@%w+{(.-),')
+    entry.kind = cmp.lsp.CompletionItemKind.Reference
 
-		table.insert(entries, entry)
-	end
+    table.insert(entries, entry)
+  end
 end
 
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
-	local words = table.concat(lines)
-	for ref in words:gmatch('{#(%a+:[%w_-]+)') do
-		local entry = {}
-		entry.label = '@' .. ref
-		entry.kind = cmp.lsp.CompletionItemKind.Reference
-		table.insert(entries, entry)
-	end
+  local words = table.concat(lines)
+  for ref in words:gmatch('{#(%a+:[%w_-]+)') do
+    local entry = {}
+    entry.label = '@' .. ref
+    entry.kind = cmp.lsp.CompletionItemKind.Reference
+    table.insert(entries, entry)
+  end
 end
 
 -- Returns the entries as a table, clearing entries beforehand
 function M.get_entries(lines)
-	local location = locate_bib(lines)
-	entries = {}
+  local location = locate_bib(lines)
+  entries = {}
 
-	if location and vim.fn.filereadable(location) == 1 then
-		parse_bib(location)
-	end
-	parse_ref(lines)
+  if location and vim.fn.filereadable(location) == 1 then
+    parse_bib(location)
+  end
+  parse_ref(lines)
 
-	return entries
+  return entries
 end
 
 return M


### PR DESCRIPTION
Allows this plugin to also work with bibliography files defined in a `_quarto.yml` file as used by quarto projects.

refs #5 