### PR TITLE
Add figure previews and fix Zotero-related issues with bib parsing

### DIFF
--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -58,8 +58,27 @@ local function parse_bib(filename)
 	end
 end
 
-local function latex_preview(str)
-  return str
+local function latex_preview(str, sep)
+  local nabla_avilable, _ = pcall(require, "nabla")
+
+  if not nabla_avilable then
+    return str
+  end
+  
+  -- undo table -> string with separator
+  str_table = {}
+  for match in str:gmatch("[^" .. sep .. "]+") do
+    str = match
+    table.insert(str_table, match)
+  end
+
+  str_table = require("nabla").gen_drawing(str_table)
+
+  if str_table == 0 then
+    return str
+  end
+
+  return table.concat(str_table, "\n")
 end
 
 -- Parses the references in the current file, formatting for completion
@@ -82,7 +101,7 @@ local function parse_ref(lines)
       local entry = {}
 
       if type == "equation" then
-        desc = latex_preview(desc)
+        desc = latex_preview(desc, "\n")
       end
 
       entry.documentation = {

--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -17,6 +17,8 @@ end
 local function clean(text)
   if text then
     text = text:gsub('\n', ' ')
+    -- Remove { or } tokens inserted by Zotero
+    text = text:gsub('[{}]+', '')
     return text:gsub('%s%s+', ' ')
   else
     return text
@@ -28,19 +30,26 @@ end
 local function parse_bib(filename)
 	local file = io.open(filename, 'rb')
 	local bibentries = file:read('*all')
+
 	file:close()
+
 	for bibentry in bibentries:gmatch('@.-\n}\n') do
 		local entry = {}
 
-		local title = clean(bibentry:match('title%s*=%s*["{]*(.-)["}],?')) or ''
-		local author = clean(bibentry:match('author%s*=%s*["{]*(.-)["}],?')) or ''
-		local year = bibentry:match('year%s*=%s*["{]?(%d+)["}]?,?') or ''
+    -- regex courtesy from /aspeddro/cmp-pandoc.nvim
+    local title = bibentry:match("title%s*=%s*[{]*(.-)[}],") or "***NOTITLE***"
+    local author = bibentry:match('[ae][ud][ti][ht][o][r]%s*=%s*["{]*(.-)["}],?') or "***NOAUTHOR***"
+    local year = bibentry:match('[yd][ea][at][re]%s*=%s*["{]?(%d+)["}]?,?') or "***NODATE***"
 
-		local doc = {'**' .. title .. '**', '', '*' .. author .. '*', year}
+		local doc = {
+      '**' .. clean(title) .. '**', 
+      '*' .. clean(author) .. '*', 
+      year
+    }
 
 		entry.documentation = {
 			kind = cmp.lsp.MarkupKind.Markdown,
-			value = table.concat(doc, '\n')
+			value = table.concat(doc, '\n\n')
 		}
 		entry.label = '@' .. bibentry:match('@%w+{(.-),')
 		entry.kind = cmp.lsp.CompletionItemKind.Reference
@@ -49,15 +58,44 @@ local function parse_bib(filename)
 	end
 end
 
+local function latex_preview(str)
+  return str
+end
+
 -- Parses the references in the current file, formatting for completion
 local function parse_ref(lines)
-	local words = table.concat(lines)
-	for ref in words:gmatch('{#(%a+:[%w_-]+)') do
-		local entry = {}
-		entry.label = '@' .. ref
-		entry.kind = cmp.lsp.CompletionItemKind.Reference
-		table.insert(entries, entry)
-	end
+	local buffer = table.concat(lines, "\n")
+
+  reference = '{#(%a+:[%w_-]+)}'
+  matchers = {
+    equation = { title = "**Equation**", regex = "%$%$\n?(.-)\n?%$%$" },
+    listing = { title = "**Listing**", regex = "```.-```\n\n: (.-) "},
+    table = { title = "**Table**", regex = "|.-|.-\n\n: (.-) " },
+    figure = { title = "**Figure**", regex = "(!%[.-%])%(?.-%)?"}
+  }
+
+  for type, matcher in pairs(matchers) do
+    local num = 0
+
+    for desc, ref in buffer:gmatch(matcher.regex .. reference) do
+      num = num + 1
+      local entry = {}
+
+      if type == "equation" then
+        desc = latex_preview(desc)
+      end
+
+      entry.documentation = {
+        kind = cmp.lsp.MarkupKind.Markdown,
+
+        value = matcher.title .. " **(" ..  num .. ")**" .. "\n\n" .. desc
+      }
+      entry.label = '@' .. ref
+      entry.kind = cmp.lsp.CompletionItemKind.Reference
+
+      table.insert(entries, entry)
+    end
+  end
 end
 
 -- Returns the entries as a table, clearing entries beforehand


### PR DESCRIPTION
Now also shows table, figure, listing and equation previews in the documentation tab in cmp. Also fix some Zotero-related issues with bib parsing (in Zotero `{{}}` are added around certain words to add emphasis, but I've decided to just ignore these).

[Screencast from 2023-12-23 14-43-48.webm](https://github.com/jc-doyle/cmp-pandoc-references/assets/29454592/b1f63d1c-8850-4eb9-bd76-84e2478f18ad)

The I thought about creating my own regex strings to fix the bib matching, but the ones from the related project https://github.com/aspeddro/cmp-pandoc.nvim/tree/main work very well. Since this is licensed under the MIT license, I've added the appropriate credits there.

I'm also working on a latex preview for the equations, but I'm still working on that. (Just wanted to mention why the `latex_preview` function is empty).

EDIT: Latex previews now work (using `nabla` like cmp-pandoc, but implemented slightly differently).
