### PR TITLE
strip quotes around bibfile path

### DIFF
--- a/lua/cmp-pandoc-references/references.lua
+++ b/lua/cmp-pandoc-references/references.lua
@@ -8,7 +8,8 @@ local function locate_bib(lines)
 	for _, line in ipairs(lines) do
 		location = string.match(line, 'bibliography: (%g+)')
 		if location then
-			return location
+			local trimmed, _ = location:gsub('^[\'"](.*)[\'"]$', '%1')
+			return trimmed
 		end
 	end
 end


### PR DESCRIPTION
sometimes bibfile path is quoted, for instances to avoid escaping special characters

```
bibliography: "@something.bib"
```

this PR strips eventual quotes, so that such file is found